### PR TITLE
Fix kotlin target version

### DIFF
--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -35,7 +35,7 @@ android {
         targetCompatibility versions.sdk.compatibility
     }
     kotlinOptions {
-        jvmTarget = versions.kotlin.jvm
+        jvmTarget = versions.kotlin.jvm.toString()
     }
 }
 

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -31,11 +31,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility versions.sdk.compatibility
+        targetCompatibility versions.sdk.compatibility
     }
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17
+        jvmTarget = versions.kotlin.jvm
     }
 }
 

--- a/scripts/dependencies.gradle
+++ b/scripts/dependencies.gradle
@@ -2,7 +2,9 @@ ext {
     //region Versions
     versions = [:]
     versions.sdk = [:]
+    versions.kotlin = [:]
     versions.sdk.compatibility = JavaVersion.VERSION_17
+    versions.kotlin.jvm = 17
     //endregion
 
     //region Libraries

--- a/tka/build.gradle
+++ b/tka/build.gradle
@@ -14,5 +14,9 @@ dependencies {
     testImplementation libraries.junit
 }
 
+kotlin {
+    jvmToolchain(versions.kotlin.jvm)
+}
+
 sourceCompatibility = versions.sdk.compatibility
 targetCompatibility = versions.sdk.compatibility


### PR DESCRIPTION
This PR fixes a JVM compatibility between Java and Kotlin compilation targets when running the project in a machine with a different JVM version

The original configuration used:

```
compileJava → JVM 17
compileKotlin → JVM 21
```

This caused Gradle to throw an error about inconsistent JVM targets.

`Inconsistent JVM-target compatibility detected for tasks 'compileJava' (17) and 'compileKotlin' (21).
`

The fix is to apply the same JVM version to the kotlin Compiler. 

## How To Test

1. Use a machine with a java version >17
2. Run a task like `./gradlew :tka:test`
3. Without the fix it fails with the above error, with this fix the test task finishes with success.